### PR TITLE
Bottle's cathcall setting

### DIFF
--- a/bottle_jsonrpc.py
+++ b/bottle_jsonrpc.py
@@ -64,6 +64,8 @@ class NameSpace:
                     'error': None,
                 }                
             except:
+                if not self.app.catchall:
+                    raise
                 traceback.print_exc(file=sys.stderr)
                 response = { 
                     'id': request['id'],


### PR DESCRIPTION
bottle_jsonrpc now takes into account bottle's `app.catchall` setting while handling exceptions
